### PR TITLE
Update Type selector

### DIFF
--- a/dev/binarize.js
+++ b/dev/binarize.js
@@ -116,10 +116,14 @@ var find_type = function(obj) {
 
     } else {
         var const_name = obj.constructor.name;
-        if (const_name !== undefined) {
+        var const_name_reflection = obj.constructor.toString().match(/\w+/g)[1];
+        if (const_name !== undefined && Types[const_name.toUpperCase()] !== undefined) {
             // return type by .constructor.name if possible
             type = Types[const_name.toUpperCase()];
 
+        } else if(const_name_reflection !== undefined && Types[const_name_reflection.toUpperCase()] !== undefined) {                
+                type = Types[const_name_reflection.toUpperCase()];
+        
         } else {
             // Work around when constructor.name is not defined
             switch (typeof obj) {


### PR DESCRIPTION
When you use 
var const_name = obj.constructor.name;
with Webpack return "O" for framebuffer and I suspect with other types, but isn`t a valid type, so this changes,
* Check if the type exist
* Provide a way to extract the type by "reflection"

Thank you regards